### PR TITLE
Bug Fix: FENIX-15818 - Support student numbers with 6 digits

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,3 +1,5 @@
+- Bug Fix: FENIX-15818 - Support student numbers with 6 digits
+
 2.12.2 (28-08-2024)
 - Refactor:  Support to  multiple active calendars [#UL-FC-5116]
 

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,4 +1,4 @@
-- Bug Fix: FENIX-15818 - Support student numbers with 6 digits
+- Bug Fix: Support student numbers with 6 digits [FENIX-15818]
 
 2.12.2 (28-08-2024)
 - Refactor:  Support to  multiple active calendars [#UL-FC-5116]


### PR DESCRIPTION
The first implementation had code from Old Iscte Fenix that restricted the student number to 5 digits (99999).
Currently the student number can have 6 digits (max 999999).