### PR TITLE
Improvement: FENIX-15817 - CgdStudentPhotoClient credentials

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,3 +1,5 @@
+- Improvement: FENIX-15817 - Add support to setup credentials in CgdStudentPhotoClient constructor
+
 2.12.2 (28-08-2024)
 - Refactor:  Support to  multiple active calendars [#UL-FC-5116]
 

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,4 +1,4 @@
-- Improvement: FENIX-15817 - Add support to setup credentials in CgdStudentPhotoClient constructor
+- Improvement: Add support to setup credentials in CgdStudentPhotoClient constructor [FENIX-15817]
 
 2.12.2 (28-08-2024)
 - Refactor:  Support to  multiple active calendars [#UL-FC-5116]

--- a/src/main/java/com/qubit/solution/fenixedu/integration/cgd/services/studentPhoto/CgdStudentPhotoClient.java
+++ b/src/main/java/com/qubit/solution/fenixedu/integration/cgd/services/studentPhoto/CgdStudentPhotoClient.java
@@ -30,6 +30,14 @@ public class CgdStudentPhotoClient extends BennuWebServiceClient<IStudentPhotoSe
     public static final String EMPLOYEE_IDENTIFICATION_CODE = "71";
     public static final String TEACHER_IDENTIFICATION_CODE = "81";
 
+    public CgdStudentPhotoClient() {
+        super();
+    }
+
+    public CgdStudentPhotoClient(String username, String password) {
+        super(username, password);
+    }
+
     @Override
     protected BindingProvider getService() {
         return (BindingProvider) new StudentPhotoService().getBasicHttpBindingPhotoStudentService();


### PR DESCRIPTION
CGD gave two pairs of credentials to Iscte, one for Lisboa, with the user U6800 and another one for Sintra, with the user U6810.

Since there is only one instance of the CgdStudentPhotoClient in Fenix, we must be able to set the credentials in the constructor instead of using the raw ones in the WebServiceClientConfiguration. Actually in the client of the WS we have the credentials in the WebServiceClientConfiguration, using a string like "###" as the separator.

With this improvement, when we create the CgdStudentPhotoClient instance we will pass the right credentials (Lisboa or Sintra), retrieving the from the WebServiceClientConfiguration and splinting them with "###" to fetch the right one :)