### PR TITLE
Bug Fix: FENIX-15402 - CgdIntegrationService: NumberFormatException

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,4 +1,4 @@
-- Bug Fix: FENIX-15402 - CgdIntegrationService: NumberFormatException when student number not a number. Ticket ISCTE-FENIXEDU-637
+- Bug Fix: CgdIntegrationService - NumberFormatException when student number not a number. (FENIX-15402) [ISCTE-FENIXEDU-637]
 
 2.12.2 (28-08-2024)
 - Refactor:  Support to  multiple active calendars [#UL-FC-5116]

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,3 +1,5 @@
+- Bug Fix: FENIX-15402 - CgdIntegrationService: NumberFormatException when student number not a number. Ticket ISCTE-FENIXEDU-637
+
 2.12.2 (28-08-2024)
 - Refactor:  Support to  multiple active calendars [#UL-FC-5116]
 

--- a/src/main/java/com/qubit/solution/fenixedu/integration/cgd/services/memberid/StudentNumberAdapter.java
+++ b/src/main/java/com/qubit/solution/fenixedu/integration/cgd/services/memberid/StudentNumberAdapter.java
@@ -28,10 +28,14 @@ package com.qubit.solution.fenixedu.integration.cgd.services.memberid;
 
 import org.fenixedu.academic.domain.Person;
 import org.fenixedu.academic.domain.student.Student;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.qubit.solution.fenixedu.integration.cgd.webservices.resolver.memberid.IMemberIDAdapter;
 
 public class StudentNumberAdapter implements IMemberIDAdapter {
+
+    private static Logger logger = LoggerFactory.getLogger(StudentNumberAdapter.class);
 
     @Override
     public String retrieveMemberID(Person person) {
@@ -41,8 +45,13 @@ public class StudentNumberAdapter implements IMemberIDAdapter {
 
     @Override
     public Person readPerson(String memberID) {
-        Student readStudentByNumber = Student.readStudentByNumber(Integer.valueOf(memberID));
-        return readStudentByNumber != null ? readStudentByNumber.getPerson() : null;
+        try {
+            Student readStudentByNumber = Student.readStudentByNumber(Integer.valueOf(memberID));
+            return readStudentByNumber != null ? readStudentByNumber.getPerson() : null;
+        } catch (NumberFormatException ex) {
+            logger.error(String.format("Invalid student number: %s", memberID), ex);
+            return null;
+        }
     }
 
 }


### PR DESCRIPTION
Ticket ISCTE-FENIXEDU-637
This happens when CGD sends a student number that is not a number.

There are some student member in CGD database that the member code/number is not a number, although Iscte only sends the student number...

When CGD calls Fenix WS, a NumberFormatException was being thrown, instead of replying
`
<S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/">
   <S:Body>
      <ns2:searchMemberResponse xmlns:ns2="http://webservices.cgd.integration.fenixedu.solution.qubit.com/">
         <return>
            <replyCode>9</replyCode>
         </return>
      </ns2:searchMemberResponse>
   </S:Body>
</S:Envelope>
`
CGD contact claims this breaks the integration queue from their side, so we must reply with the code 9, otherwise they will not call our WS for the remaining pending members...