### PR TITLE
New Feature: Write to log all WS CgdIntegrationService calls

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,3 +1,5 @@
+- New Feature: Write to log all WS CgdIntegrationService calls (FENIX-15291) [ISCTE-FENIXEDU-575]
+
 2.12.2 (28-08-2024)
 - Refactor:  Support to  multiple active calendars [#UL-FC-5116]
 

--- a/src/main/java/com/qubit/solution/fenixedu/integration/cgd/webservices/CgdIntegrationService.java
+++ b/src/main/java/com/qubit/solution/fenixedu/integration/cgd/webservices/CgdIntegrationService.java
@@ -35,6 +35,7 @@ import org.joda.time.format.DateTimeFormat;
 
 import com.qubit.solution.fenixedu.bennu.webservices.services.server.BennuWebService;
 import com.qubit.solution.fenixedu.integration.cgd.domain.logs.CgdCommunicationLog;
+import com.qubit.solution.fenixedu.integration.cgd.webservices.messages.CgdMessageUtils;
 import com.qubit.solution.fenixedu.integration.cgd.webservices.messages.member.SearchMemberInput;
 import com.qubit.solution.fenixedu.integration.cgd.webservices.messages.member.SearchMemberOutput;
 import com.qubit.solution.fenixedu.integration.cgd.webservices.messages.mifare.UpdateMifareInputMessage;
@@ -47,35 +48,60 @@ public class CgdIntegrationService extends BennuWebService {
 
     @WebMethod
     public SearchMemberOutput searchMember(SearchMemberInput message) {
-        SearchMemberOutput outputMessage = new SearchMemberOutput();
-        Person identifiedPerson = message.getIdentifiedPerson();
-        if (identifiedPerson != null) {
-            outputMessage.populate(identifiedPerson, message.getPopulationCode(), message.getMemberCode(), message.getMemberID());
-            CgdCommunicationLog.findLatestStudentLog(identifiedPerson).ifPresent(log -> log.updateSearchDate());
+        final String methodName = "searchMember";
+        try {
+            SearchMemberOutput outputMessage = new SearchMemberOutput();
+            Person identifiedPerson = message.getIdentifiedPerson();
+            if (identifiedPerson != null) {
+                outputMessage.populate(identifiedPerson, message.getPopulationCode(), message.getMemberCode(),
+                        message.getMemberID());
+                CgdCommunicationLog.findLatestStudentLog(identifiedPerson).ifPresent(log -> log.updateSearchDate());
+            }
+
+            CgdMessageUtils.log(methodName, message, outputMessage);
+            return outputMessage;
+        } catch (Exception ex) {
+            CgdMessageUtils.log(methodName, message, ex);
+            throw ex;
         }
-        return outputMessage;
     }
 
     @WebMethod
     public SearchMemberPhotoOuputMessage searchPhoto(SearchMemberPhotoInputMessage message) {
-        SearchMemberPhotoOuputMessage outputMessage = new SearchMemberPhotoOuputMessage();
-        Person person = message.getIdentifiedPerson();
-        if (person != null) {
-            outputMessage.populate(person, message.getPopulationCode(), message.getMemberCode(), message.getMemberID());
+        final String methodName = "searchPhoto";
+        try {
+            SearchMemberPhotoOuputMessage outputMessage = new SearchMemberPhotoOuputMessage();
+            Person person = message.getIdentifiedPerson();
+            if (person != null) {
+                outputMessage.populate(person, message.getPopulationCode(), message.getMemberCode(), message.getMemberID());
+            }
+
+            CgdMessageUtils.log(methodName, message, outputMessage);
+            return outputMessage;
+        } catch (Exception ex) {
+            CgdMessageUtils.log(methodName, message, ex);
+            throw ex;
         }
-        return outputMessage;
     }
 
     @WebMethod
     public UpdateMifareOutputMessage updateChip(UpdateMifareInputMessage message) {
-        UpdateMifareOutputMessage outputMessage = new UpdateMifareOutputMessage();
-        Person person = message.getIdentifiedPerson();
-        if (person != null) {
-            outputMessage.populate(person, message.getPopulationCode(), message.getMemberCode(), message.getMemberID(),
-                    message.getChipData(), message.getCardIdentification(),
-                    LocalDate.parse(message.getPersonalizationDate(), DateTimeFormat.forPattern("YYYY-MM-dd")));
+        final String methodName = "updateChip";
+        try {
+            UpdateMifareOutputMessage outputMessage = new UpdateMifareOutputMessage();
+            Person person = message.getIdentifiedPerson();
+            if (person != null) {
+                outputMessage.populate(person, message.getPopulationCode(), message.getMemberCode(), message.getMemberID(),
+                        message.getChipData(), message.getCardIdentification(),
+                        LocalDate.parse(message.getPersonalizationDate(), DateTimeFormat.forPattern("YYYY-MM-dd")));
+            }
+
+            CgdMessageUtils.log(methodName, message, outputMessage);
+            return outputMessage;
+        } catch (Exception ex) {
+            CgdMessageUtils.log(methodName, message, ex);
+            throw ex;
         }
-        return outputMessage;
     }
 
 }

--- a/src/main/java/com/qubit/solution/fenixedu/integration/cgd/webservices/messages/CgdMessageUtils.java
+++ b/src/main/java/com/qubit/solution/fenixedu/integration/cgd/webservices/messages/CgdMessageUtils.java
@@ -34,15 +34,20 @@ import org.fenixedu.academic.domain.Person;
 import org.fenixedu.academic.domain.Teacher;
 import org.fenixedu.academic.domain.student.Student;
 import org.fenixedu.bennu.core.groups.DynamicGroup;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.qubit.solution.fenixedu.integration.cgd.domain.configuration.CgdIntegrationConfiguration;
 import com.qubit.solution.fenixedu.integration.cgd.webservices.resolver.memberid.IMemberIDAdapter;
+import com.qubit.terra.framework.services.logging.Log;
+import com.qubit.terra.framework.services.logging.LogContext;
 
 public class CgdMessageUtils {
 
-    private static Logger logger = LoggerFactory.getLogger(CgdMessageUtils.class);
+    private static final LogContext LOG = LogContext.forContext(CgdMessageUtils.class.getSimpleName());
+
+    public static String SUMMARY_FIELD_SEPARATOR = "#";
+    public static String SUMMARY_FIELD_COLUMN_SEPARATOR = "|";
+    public static String SUMMARY_FIELD_COLUMN_LIST_ELEMENT_SEPARATOR = ",";
+    public static String SUMMARY_FIELD_COLUMN_NULL = "-";
 
     public static int REPLY_CODE_OPERATION_OK = 0;
     public static int REPLY_CODE_INFORMATION_NOT_OK = 1;
@@ -59,7 +64,7 @@ public class CgdMessageUtils {
                     int number = Integer.parseInt(memberCode);
                     student = Student.readStudentByNumber(number);
                 } catch (Exception e) {
-                    logger.warn(String.format("Invalid student number: [%s]", memberCode));
+                    Log.warn(String.format("Invalid student number: [%s]", memberCode));
                 }
 
                 if (student != null) {
@@ -105,5 +110,21 @@ public class CgdMessageUtils {
 
     public static IMemberIDAdapter getMemberIDStrategy() {
         return CgdIntegrationConfiguration.getInstance().getMemberIDStrategy();
+    }
+
+    public static void log(String webmethodName, ISummaryMessage inputMessage, ISummaryMessage outputMessage) {
+        // TODO find a way to detect that the log is in DEBUG, to prevent unneeded overhead.
+        //
+        //        if (Log.isEnabledForLogLevel(LogLevel.DEBUG)) {
+        // Only build log message if in debug to avoid unneeded overhead.
+        String msg =
+                String.format("%s#%s#%s", webmethodName, inputMessage.getSummaryMessage(), outputMessage.getSummaryMessage());
+        Log.debug(LOG, msg);
+        //        }
+    }
+
+    public static void log(String webmethodName, ISummaryMessage inputMessage, Exception ex) {
+        String msg = String.format("%s#%s", webmethodName, inputMessage.getSummaryMessage());
+        Log.error(LOG, msg, ex);
     }
 }

--- a/src/main/java/com/qubit/solution/fenixedu/integration/cgd/webservices/messages/ISummaryMessage.java
+++ b/src/main/java/com/qubit/solution/fenixedu/integration/cgd/webservices/messages/ISummaryMessage.java
@@ -1,0 +1,18 @@
+package com.qubit.solution.fenixedu.integration.cgd.webservices.messages;
+
+/**
+ * Interface to use in web methods input and output DTOs.
+ * 
+ * @author Antonio Casqueiro | Iscte
+ */
+public interface ISummaryMessage {
+
+    /**
+     * This method is to be called in a simplified log feature.
+     * Instead of returning all the DTO data, return only the one relevant for supporting proposed.
+     * 
+     * @return summary relevant log data
+     */
+    String getSummaryMessage();
+
+}

--- a/src/main/java/com/qubit/solution/fenixedu/integration/cgd/webservices/messages/member/SearchMemberInput.java
+++ b/src/main/java/com/qubit/solution/fenixedu/integration/cgd/webservices/messages/member/SearchMemberInput.java
@@ -37,8 +37,9 @@ import org.fenixedu.academic.domain.person.IDDocumentType;
 
 import com.qubit.solution.fenixedu.integration.cgd.domain.configuration.CgdIntegrationConfiguration;
 import com.qubit.solution.fenixedu.integration.cgd.webservices.messages.CgdMessageUtils;
+import com.qubit.solution.fenixedu.integration.cgd.webservices.messages.ISummaryMessage;
 
-public class SearchMemberInput implements Serializable {
+public class SearchMemberInput implements Serializable, ISummaryMessage {
 
     private static int IDCARD_TYPE = 101;
     private static int TAXNUMBER_TYPE = 501;
@@ -155,4 +156,20 @@ public class SearchMemberInput implements Serializable {
         }
         return requestedPerson;
     }
+
+    @Override
+    public String getSummaryMessage() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(populationCode != null ? populationCode : CgdMessageUtils.SUMMARY_FIELD_COLUMN_NULL);
+        sb.append(CgdMessageUtils.SUMMARY_FIELD_COLUMN_SEPARATOR);
+        sb.append(memberID != null ? memberID : CgdMessageUtils.SUMMARY_FIELD_COLUMN_NULL);
+        sb.append(CgdMessageUtils.SUMMARY_FIELD_COLUMN_SEPARATOR);
+        sb.append(documentType != null ? documentType : CgdMessageUtils.SUMMARY_FIELD_COLUMN_NULL);
+        sb.append(CgdMessageUtils.SUMMARY_FIELD_COLUMN_SEPARATOR);
+        sb.append(documentID != null ? documentID : CgdMessageUtils.SUMMARY_FIELD_COLUMN_NULL);
+        sb.append(CgdMessageUtils.SUMMARY_FIELD_COLUMN_SEPARATOR);
+        sb.append(memberCode != null ? memberCode : CgdMessageUtils.SUMMARY_FIELD_COLUMN_NULL);
+        return sb.toString();
+    }
+    
 }

--- a/src/main/java/com/qubit/solution/fenixedu/integration/cgd/webservices/messages/member/SearchMemberOutput.java
+++ b/src/main/java/com/qubit/solution/fenixedu/integration/cgd/webservices/messages/member/SearchMemberOutput.java
@@ -20,9 +20,10 @@ import org.fenixedu.academic.domain.student.Student;
 import org.fenixedu.bennu.core.groups.DynamicGroup;
 
 import com.qubit.solution.fenixedu.integration.cgd.webservices.messages.CgdMessageUtils;
+import com.qubit.solution.fenixedu.integration.cgd.webservices.messages.ISummaryMessage;
 import com.qubit.solution.fenixedu.integration.cgd.webservices.resolver.memberid.IMemberIDAdapter;
 
-public class SearchMemberOutput implements Serializable {
+public class SearchMemberOutput implements Serializable, ISummaryMessage {
 
     private int replyCode;
     private List<SearchMemberOutputData> memberInfo;
@@ -135,5 +136,21 @@ public class SearchMemberOutput implements Serializable {
 //        } else {
 //            setReplyCode(CgdMessageUtils.REPLY_CODE_INFORMATION_NOT_OK);
 //        }
+    }
+
+    @Override
+    public String getSummaryMessage() {
+        String listData = null;
+        if (memberInfo != null) {
+            listData = memberInfo.stream() //
+                    .map(e -> e.getSummaryMessage()) //
+                    .collect(Collectors.joining(CgdMessageUtils.SUMMARY_FIELD_COLUMN_LIST_ELEMENT_SEPARATOR));
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(replyCode);
+        sb.append(CgdMessageUtils.SUMMARY_FIELD_COLUMN_SEPARATOR);
+        sb.append(listData != null ? listData : CgdMessageUtils.SUMMARY_FIELD_COLUMN_NULL);
+        return sb.toString();
     }
 }

--- a/src/main/java/com/qubit/solution/fenixedu/integration/cgd/webservices/messages/member/SearchMemberOutputData.java
+++ b/src/main/java/com/qubit/solution/fenixedu/integration/cgd/webservices/messages/member/SearchMemberOutputData.java
@@ -48,9 +48,11 @@ import org.fenixedu.bennu.core.domain.Bennu;
 import org.fenixedu.treasury.util.FiscalCodeValidation;
 import org.fenixedu.treasury.util.TreasuryConstants;
 
+import com.qubit.solution.fenixedu.integration.cgd.webservices.messages.CgdMessageUtils;
+import com.qubit.solution.fenixedu.integration.cgd.webservices.messages.ISummaryMessage;
 import com.qubit.solution.fenixedu.integration.cgd.webservices.resolver.memberid.IMemberIDAdapter;
 
-public class SearchMemberOutputData implements Serializable {
+public class SearchMemberOutputData implements Serializable, ISummaryMessage {
 
     // Single character to identify type of member
     // A - student
@@ -284,6 +286,41 @@ public class SearchMemberOutputData implements Serializable {
         searchMemberOutputData.setTeacherNumber(person.getUsername());
 
         return searchMemberOutputData;
+    }
+
+    @Override
+    public String getSummaryMessage() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(populationCode != null ? populationCode : CgdMessageUtils.SUMMARY_FIELD_COLUMN_NULL);
+        sb.append(CgdMessageUtils.SUMMARY_FIELD_COLUMN_SEPARATOR);
+        sb.append(memberID != null ? memberID : CgdMessageUtils.SUMMARY_FIELD_COLUMN_NULL);
+        sb.append(CgdMessageUtils.SUMMARY_FIELD_COLUMN_SEPARATOR);
+//        sb.append(name != null ? name : CgdMessageUtils.SUMMARY_FIELD_COLUMN_NULL);
+//        sb.append(CgdMessageUtils.SUMMARY_FIELD_COLUMN_SEPARATOR);
+        sb.append(studentNumber != null ? studentNumber : CgdMessageUtils.SUMMARY_FIELD_COLUMN_NULL);
+        sb.append(CgdMessageUtils.SUMMARY_FIELD_COLUMN_SEPARATOR);
+        sb.append(degreeCode != null ? degreeCode : CgdMessageUtils.SUMMARY_FIELD_COLUMN_NULL);
+        sb.append(CgdMessageUtils.SUMMARY_FIELD_COLUMN_SEPARATOR);
+//        sb.append(degreeName != null ? degreeName : CgdMessageUtils.SUMMARY_FIELD_COLUMN_NULL);
+//        sb.append(CgdMessageUtils.SUMMARY_FIELD_COLUMN_SEPARATOR);
+//        sb.append(degreeType != null ? degreeType : CgdMessageUtils.SUMMARY_FIELD_COLUMN_NULL);
+//        sb.append(CgdMessageUtils.SUMMARY_FIELD_COLUMN_SEPARATOR);
+//        sb.append(degreeDuration != null ? degreeDuration : CgdMessageUtils.SUMMARY_FIELD_COLUMN_NULL);
+//        sb.append(CgdMessageUtils.SUMMARY_FIELD_COLUMN_SEPARATOR);
+//        sb.append(curricularYear != null ? curricularYear : CgdMessageUtils.SUMMARY_FIELD_COLUMN_NULL);
+//        sb.append(CgdMessageUtils.SUMMARY_FIELD_COLUMN_SEPARATOR);
+//        sb.append(teacherCategory != null ? teacherCategory : CgdMessageUtils.SUMMARY_FIELD_COLUMN_NULL);
+//        sb.append(CgdMessageUtils.SUMMARY_FIELD_COLUMN_SEPARATOR);
+        sb.append(teacherNumber != null ? teacherNumber : CgdMessageUtils.SUMMARY_FIELD_COLUMN_NULL);
+        sb.append(CgdMessageUtils.SUMMARY_FIELD_COLUMN_SEPARATOR);
+//        sb.append(establishmentCode != null ? establishmentCode : CgdMessageUtils.SUMMARY_FIELD_COLUMN_NULL);
+//        sb.append(CgdMessageUtils.SUMMARY_FIELD_COLUMN_SEPARATOR);
+//        sb.append(establishmentName != null ? establishmentName : CgdMessageUtils.SUMMARY_FIELD_COLUMN_NULL);
+//        sb.append(CgdMessageUtils.SUMMARY_FIELD_COLUMN_SEPARATOR);
+        sb.append(stayingIndicator != null ? stayingIndicator : CgdMessageUtils.SUMMARY_FIELD_COLUMN_NULL);
+        sb.append(CgdMessageUtils.SUMMARY_FIELD_COLUMN_SEPARATOR);
+//        sb.append(fiscalCode);
+        return sb.toString();
     }
 
 }

--- a/src/main/java/com/qubit/solution/fenixedu/integration/cgd/webservices/messages/mifare/UpdateMifareInputMessage.java
+++ b/src/main/java/com/qubit/solution/fenixedu/integration/cgd/webservices/messages/mifare/UpdateMifareInputMessage.java
@@ -31,8 +31,9 @@ import java.io.Serializable;
 import org.fenixedu.academic.domain.Person;
 
 import com.qubit.solution.fenixedu.integration.cgd.webservices.messages.CgdMessageUtils;
+import com.qubit.solution.fenixedu.integration.cgd.webservices.messages.ISummaryMessage;
 
-public class UpdateMifareInputMessage implements Serializable {
+public class UpdateMifareInputMessage implements Serializable, ISummaryMessage {
 
     // Single character to identify type of member
     // A - student
@@ -119,5 +120,24 @@ public class UpdateMifareInputMessage implements Serializable {
             person = CgdMessageUtils.readPersonByMemberCode(getPopulationCode(), getMemberCode());
         }
         return person;
+    }
+
+    @Override
+    public String getSummaryMessage() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(populationCode != null ? populationCode : CgdMessageUtils.SUMMARY_FIELD_COLUMN_NULL);
+        sb.append(CgdMessageUtils.SUMMARY_FIELD_COLUMN_SEPARATOR);
+        sb.append(memberID != null ? memberID : CgdMessageUtils.SUMMARY_FIELD_COLUMN_NULL);
+        sb.append(CgdMessageUtils.SUMMARY_FIELD_COLUMN_SEPARATOR);
+        sb.append(memberCode != null ? memberCode : CgdMessageUtils.SUMMARY_FIELD_COLUMN_NULL);
+        sb.append(CgdMessageUtils.SUMMARY_FIELD_COLUMN_SEPARATOR);
+//        sb.append(personalizationDate != null ? personalizationDate : CgdMessageUtils.SUMMARY_FIELD_COLUMN_NULL);
+//        sb.append(CgdMessageUtils.SUMMARY_FIELD_COLUMN_SEPARATOR);
+//        sb.append(chipDataSize);
+//        sb.append(CgdMessageUtils.SUMMARY_FIELD_COLUMN_SEPARATOR);
+//        sb.append(chipData != null ? chipData : CgdMessageUtils.SUMMARY_FIELD_COLUMN_NULL);
+//        sb.append(CgdMessageUtils.SUMMARY_FIELD_COLUMN_SEPARATOR);
+//        sb.append(cardIdentification != null ? cardIdentification : CgdMessageUtils.SUMMARY_FIELD_COLUMN_NULL);
+        return sb.toString();
     }
 }

--- a/src/main/java/com/qubit/solution/fenixedu/integration/cgd/webservices/messages/mifare/UpdateMifareOutputMessage.java
+++ b/src/main/java/com/qubit/solution/fenixedu/integration/cgd/webservices/messages/mifare/UpdateMifareOutputMessage.java
@@ -33,10 +33,11 @@ import org.joda.time.LocalDate;
 
 import com.qubit.solution.fenixedu.integration.cgd.domain.idcards.CgdCard;
 import com.qubit.solution.fenixedu.integration.cgd.webservices.messages.CgdMessageUtils;
+import com.qubit.solution.fenixedu.integration.cgd.webservices.messages.ISummaryMessage;
 
 import pt.ist.fenixframework.Atomic;
 
-public class UpdateMifareOutputMessage implements Serializable {
+public class UpdateMifareOutputMessage implements Serializable, ISummaryMessage {
 
     private int replyCode;
 
@@ -73,6 +74,11 @@ public class UpdateMifareOutputMessage implements Serializable {
         card.setIssueDate(issueDate);
         card.setTemporary(false);
         card.setCardNumber(cardId);
+    }
+
+    @Override
+    public String getSummaryMessage() {
+        return String.valueOf(replyCode);
     }
 
 }

--- a/src/main/java/com/qubit/solution/fenixedu/integration/cgd/webservices/messages/photo/SearchMemberPhotoInputMessage.java
+++ b/src/main/java/com/qubit/solution/fenixedu/integration/cgd/webservices/messages/photo/SearchMemberPhotoInputMessage.java
@@ -31,8 +31,9 @@ import java.io.Serializable;
 import org.fenixedu.academic.domain.Person;
 
 import com.qubit.solution.fenixedu.integration.cgd.webservices.messages.CgdMessageUtils;
+import com.qubit.solution.fenixedu.integration.cgd.webservices.messages.ISummaryMessage;
 
-public class SearchMemberPhotoInputMessage implements Serializable {
+public class SearchMemberPhotoInputMessage implements Serializable, ISummaryMessage {
 
     // Single character to identify type of member
     // A - student
@@ -80,6 +81,18 @@ public class SearchMemberPhotoInputMessage implements Serializable {
             person = CgdMessageUtils.readPersonByMemberCode(getPopulationCode(), getMemberCode());
         }
         return person;
+    }
+
+    @Override
+    public String getSummaryMessage() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(populationCode != null ? populationCode : CgdMessageUtils.SUMMARY_FIELD_COLUMN_NULL);
+        sb.append(CgdMessageUtils.SUMMARY_FIELD_COLUMN_SEPARATOR);
+        sb.append(memberID != null ? memberID : CgdMessageUtils.SUMMARY_FIELD_COLUMN_NULL);
+        sb.append(CgdMessageUtils.SUMMARY_FIELD_COLUMN_SEPARATOR);
+        sb.append(memberCode != null ? memberCode : CgdMessageUtils.SUMMARY_FIELD_COLUMN_NULL);
+        sb.append(CgdMessageUtils.SUMMARY_FIELD_COLUMN_SEPARATOR);
+        return sb.toString();
     }
 
 }

--- a/src/main/java/com/qubit/solution/fenixedu/integration/cgd/webservices/messages/photo/SearchMemberPhotoOuputMessage.java
+++ b/src/main/java/com/qubit/solution/fenixedu/integration/cgd/webservices/messages/photo/SearchMemberPhotoOuputMessage.java
@@ -36,8 +36,9 @@ import org.fenixedu.academicextensions.domain.person.dataShare.DataShareAuthoriz
 
 import com.qubit.solution.fenixedu.integration.cgd.services.CgdAuthorizationCodes;
 import com.qubit.solution.fenixedu.integration.cgd.webservices.messages.CgdMessageUtils;
+import com.qubit.solution.fenixedu.integration.cgd.webservices.messages.ISummaryMessage;
 
-public class SearchMemberPhotoOuputMessage implements Serializable {
+public class SearchMemberPhotoOuputMessage implements Serializable, ISummaryMessage {
 
     public static int UNAVAILABLE_PHOTO = 8;
 
@@ -93,4 +94,15 @@ public class SearchMemberPhotoOuputMessage implements Serializable {
             setReplyCode(CgdMessageUtils.REPLY_CODE_INFORMATION_NOT_OK);
         }
     }
+
+    @Override
+    public String getSummaryMessage() {
+//        StringBuilder sb = new StringBuilder();
+//        sb.append(replyCode);
+//        sb.append(CgdMessageUtils.SUMMARY_FIELD_COLUMN_SEPARATOR);
+//        sb.append(name != null ? name : CgdMessageUtils.SUMMARY_FIELD_COLUMN_NULL);
+//        return sb.toString();
+        return String.valueOf(replyCode);
+    }
+
 }


### PR DESCRIPTION
 (FENIX-15291) [ISCTE-FENIXEDU-575]

In order to better support CGD integration all call should be logged to a specific log file.
LogContext was used to be able to configure this in Fenix. The data is only written in debug, so any institution that do not want this feature, simply keep the log in INFO.

Changing to PT, pois já estou tenho o texto no meu issue do JIRA
============================================================
Assumindo que a CGD invoca diariamente ou mesmo que apenas semanalmente o universo de todos os membros, guardar todas as comunicações irá criar demasiados registos na BD.

Escrever tudo para o log, também é problemático, pelo que uma solução de compromisso é:
*    Escrever apenas os não encontrados
*    Escrever informação sucinta sobre o INPUT e OUTPUT

-  Output
    - replyCode
    - List
      - populationCode
      - studentNumber
      - teacherNumber
      - stayingIndicator
      - degreeCode

**Notas de implementação:**

1.  Usar um log especifico
2. As classes de input e output implementam um interface que tem um método que devolve a informação a registar no log como uma String
3.  Logar sucesso e excepção